### PR TITLE
Remove Owlready2 as a direct dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,13 @@ repos:
     exclude: .*(\.md|\.ttl)$
 
 - repo: https://github.com/ambv/black
-  rev: 20.8b1
+  rev: 21.4b0
   hooks:
   - id: black
     name: Blacken
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: '3.9.0'
+  rev: '3.9.1'
   hooks:
   - id: flake8
     args:

--- a/dic2owl/requirements.txt
+++ b/dic2owl/requirements.txt
@@ -1,3 +1,2 @@
 EMMO~=1.0
-Owlready2~=0.30
 PyCifRW~=4.4


### PR DESCRIPTION
Fixes #35.

As stated in #35, we can remove Owlready2 as a dependency and rely on EMMO-Python to get it instead.

**Note**: Although, we do use Owlready2 directly in the `generate_cif.py` file. I have gotten second thoughts on this. Perhaps we should instead report this in the EMMO-Python repository and ensure a broader Owlready2 dependency version range? @jesper-friis and @francescalb what do you think?

This PR also updates the `pre-commit` hooks `black` and `flake8`. No files were updated after running `pre-commit run --all-files` using the updated versions.