### PR TITLE
Ensure minimum v4.4.3 of PyCIFRW

### DIFF
--- a/dic2owl/requirements.txt
+++ b/dic2owl/requirements.txt
@@ -1,2 +1,2 @@
 EMMO~=1.0
-PyCifRW~=4.4
+PyCifRW~=4.4,>=4.4.3


### PR DESCRIPTION
While still keeping the PyCIFRW dependency at `~=4.4`, i.e., the latest v4.*, this sets the minimum allowed version to v4.4.3.

Closes #23.