### PR TITLE
Parse dicfile as string if not existing locally

### DIFF
--- a/dic2owl/dic2owl/cli.py
+++ b/dic2owl/dic2owl/cli.py
@@ -59,4 +59,8 @@ def main(args: list = None):
     if args.ttlfile is None:
         args.ttlfile = args.dicfile.resolve().name[: -len(args.dicfile.suffix)] + ".ttl"
 
+    if not args.dicfile.resolve().exists():
+        # The dic-file does not exist, use it as a string instead so it can be downloaded.
+        args.dicfile = str(args.dicfile)
+
     dic2owl_run(dicfile=args.dicfile, ttlfile=args.ttlfile)


### PR DESCRIPTION
The `dic2owl` CLI parses the input as a `pathlib.Path` object, meaning if a `cif_core.dic` is passed, it will resolve to be `/path/to/current/dir/cif_core_dic`, and this should only happen if the file already exists, otherwise it should download the dictionary from the [COMCIFS/cif_core](https://github.com/COMCIFS/cif_core) repository.