### PR TITLE
Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 [![CI tests](https://github.com/emmo-repo/CIF-ontology/workflows/CI/badge.svg)](https://github.com/emmo-repo/CIF-ontology/actions/)
 
-CIF ontology
-============
+# CIF ontology
 
 A crystallography domain ontology based on [EMMO][1] and the [CIF core][2] dictionary.
 It is implemented as a formal language.
 
-Status
-------
+## Status
 
 - [ ] Proposal
 - [X] Accepted, under development
@@ -16,8 +14,7 @@ Status
 This ontology is work-in-progress (WIP).
 It is part of the overall process of developing a domain ontology for crystallography.
 
-Imported Ontologies
--------------------
+## Imported Ontologies
 
 This ontology builds on top of EMMO.
 See the following table for version compatibilies:
@@ -26,8 +23,13 @@ See the following table for version compatibilies:
 | ------------------- | ----------------- |
 | emmo-inferred       | 1.0.0-beta        |
 
-Obtaining CIF-ontology
-----------------------
+## Generator tool (`dic2owl`)
+
+This repository contains both ontologies (under [`/ontology`](ontology)) and the `dic2owl` generator tool (under [`/dic2owl`](dic2owl)), written in Python.
+
+Go to the [README](dic2owl/README.md) of `dic2owl` to read more about the generator tool.
+
+## Obtaining CIF-ontology
 
 This ontology build on EMMO-1.0.0-beta.
 The correct path to the inferred verion 'emmo-inferred' is specified in the catalog file, [`catalog-v001.xml`](ontology/catalog-v001.xml).
@@ -52,8 +54,7 @@ cif_onto = get_ontology('/path/to/cif.ttl').load(url_from_catalog=True)
 cif_onto = get_ontology('https://raw.githubusercontent.com/emmo-repo/CIF-ontology/main/ontology/cif.ttl').load()
 ```
 
-Attributions and credits
-------------------------
+## Attributions and credits
 
 ### Contributors
 

--- a/dic2owl/README.md
+++ b/dic2owl/README.md
@@ -22,6 +22,20 @@ It has been developed by the EMMO-Crystallography EMMC Task Group, which consist
 
 This package relies on the [PyCIFRW](https://bitbucket.org/jamesrhester/pycifrw) package developed by James Hester to parse CIF (`.cif`) and CIF dictionary (`.dic`) files.
 
+## For developers
+
+### Pre-commit (Python formatting)
+
+To ensure similar formatting, this repository uses `pre-commit`, which runs prior to every `git commit`.
+Specifically, [`black`](https://github.com/psf/black) is used as the default Python formatter.
+
+To install in your local clone, `cd` to the root of the repository and run
+
+```console
+/path/to/CIF-ontology$ pre-commit install
+pre-commit installed at .git/hooks/pre-commit
+```
+
 ## Author
 
 - Jesper Friis, SINTEF


### PR DESCRIPTION
Change to `#`-style in base README and add a section that references the `dic2owl` generator tool.

Add a "For developers" section in the `dic2owl` README, which only contains information about `pre-commit` at this point.

Somewhat related to #39.