### PR TITLE
Fix todo for CIF-DDL URL after merging #52

### DIFF
--- a/dic2owl/dic2owl/dic2owl.py
+++ b/dic2owl/dic2owl/dic2owl.py
@@ -86,15 +86,9 @@ class Generator:
         self.onto = self.world.get_ontology(base_iri)
 
         # Load cif-ddl ontology and append it to imported ontologies
-        # TODO - update the url below when the dic2owl branch is merged into
-        # main...
-        # cif_ddl = (
-        #     "https://raw.githubusercontent.com/emmo-repo/CIF-ontology/main/"
-        #     "ontology/cif-ddl.ttl"
-        # )
         cif_ddl = (
-            "https://raw.githubusercontent.com/emmo-repo/CIF-ontology/dic2owl"
-            "/ontology/cif-ddl.ttl"
+            "https://raw.githubusercontent.com/emmo-repo/CIF-ontology/main/"
+            "ontology/cif-ddl.ttl"
         )
         self.ddl = self.world.get_ontology(str(cif_ddl)).load()
         self.ddl.sync_python_names()


### PR DESCRIPTION
A hard-coded URL to the `cif-ddl.ttl` file should be updated after the #52 has been merged and the `dic2owl` branch doesn't exist anymore.