### PR TITLE
Update dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: weekly
     day: monday
     time: "05:02"
-  # Should be bigger than or equal to the total number of dependencies (currently 8)
+  # Should be bigger than or equal to the total number of dependencies (currently 6)
   open-pull-requests-limit: 15
   target-branch: ci/dependabot-updates
   labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,14 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  # Should be bigger than or equal to the total number of dependencies (currently 3)
-  open-pull-requests-limit: 10
-  target-branch: main
+    day: monday
+    time: "05:02"
+  # Should be bigger than or equal to the total number of dependencies (currently 8)
+  open-pull-requests-limit: 15
+  target-branch: ci/dependabot-updates
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
-  target-branch: main
+    time: "05:04"
+  target-branch: ci/dependabot-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,13 @@ updates:
   # Should be bigger than or equal to the total number of dependencies (currently 8)
   open-pull-requests-limit: 15
   target-branch: ci/dependabot-updates
+  labels:
+    - "dependencies"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
     time: "05:04"
   target-branch: ci/dependabot-updates
+  labels:
+    - "github_actions"

--- a/.github/static/single_dependency_pr_body.txt
+++ b/.github/static/single_dependency_pr_body.txt
@@ -1,0 +1,10 @@
+### Update dependencies
+
+Automatically created PR from [`ci/dependabot-updates`](https://github.com/emmo-repo/CIF-ontology/tree/ci/dependabot-updates).
+
+For more information see the ["Dependabot updates" workflow](https://github.com/emmo-repo/CIF-ontology/blob/master/.github/workflows/ci_dependabot.yml).
+
+#### To-do
+
+- [ ] Check that the diff is sensible, and that tests and builds pass with the new dependency versions.
+- [ ] Make sure that the PR is **squash** merged, with a sensible commit message.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,23 +3,57 @@ name: CI
 on: [push]
 
 jobs:
-
   pre-commit:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+    - name: Checkout repository
+      uses: actions/checkout@v2
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -U setuptools wheel
-          pip install pre-commit
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools wheel
 
-      - name: Run pre-commit
-        run: pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
+        while IFS="" read -r line || [ -n "${line}" ]; do
+          if [[ "${line}" =~ ^pre-commit.*$ ]]; then
+            pre_commit="${line}"
+          fi
+        done < dic2owl/requirements_dev.txt
+
+        pip install ${pre_commit}
+
+    - name: Run pre-commit
+      run: SKIP=pylint pre-commit run --all-files
+
+  pylint-safety:
+    name: PyLint and safety
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools wheel
+
+        pip install -U -r requirements.txt -r requirements_dev.txt -r requirements_docs.txt
+        pip install safety
+
+    - name: Run PyLint
+      run: pylint --rcfile=pyproject.toml dic2owl
+
+    - name: Run safety
+      run: pip freeze | safety check --stdin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -U setuptools wheel
 
-        pip install -U -r requirements.txt -r requirements_dev.txt -r requirements_docs.txt
+        pip install -U -r dic2owl/requirements.txt -r dic2owl/requirements_dev.txt
         pip install safety
 
     - name: Run PyLint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         pip install safety
 
     - name: Run PyLint
-      run: pylint --rcfile=dic2owl/pyproject.toml dic2owl
+      run: pylint --rcfile=dic2owl/pyproject.toml dic2owl/**/*.py
 
     - name: Run safety
       run: pip freeze | safety check --stdin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         pip install safety
 
     - name: Run PyLint
-      run: pylint --rcfile=pyproject.toml dic2owl
+      run: pylint --rcfile=dic2owl/pyproject.toml dic2owl
 
     - name: Run safety
       run: pip freeze | safety check --stdin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.7
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 jobs:
-  pre-commit:
+  pre-commit-basic:
     runs-on: ubuntu-latest
 
     steps:
@@ -29,31 +29,4 @@ jobs:
         pip install ${pre_commit}
 
     - name: Run pre-commit
-      run: SKIP=pylint pre-commit run --all-files
-
-  pylint-safety:
-    name: PyLint and safety
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U setuptools wheel
-
-        pip install -U -r dic2owl/requirements.txt -r dic2owl/requirements_dev.txt
-        pip install safety
-
-    - name: Run PyLint
-      run: pylint --rcfile=dic2owl/pyproject.toml dic2owl/**/*.py
-
-    - name: Run safety
-      run: pip freeze | safety check --stdin
+      run: SKIP=pylint,mypy,black,bandit,requirements-txt-fixer pre-commit run --all-files

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -1,0 +1,30 @@
+name: CI - Activate auto-merging for Dependabot PRs
+
+on:
+  pull_request_target:
+    branches: [ci/dependabot-updates]
+
+jobs:
+  update-dependabot-branch:
+    name: Update permanent dependabot branch
+    if: github.repository_owner == 'emmo-repo' && startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    env:
+      DEPENDABOT_BRANCH: ci/dependabot-updates
+      GIT_USER_NAME: CIF-ontology Team
+      GIT_USER_EMAIL: "CIF-ontology@emmo.info"
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Activate auto-merge
+      run: |
+        PR_ID="$(gh api graphql -F owner='{owner}' -F name='{repo}' -f query='query($owner: String!, $name: String!) {repository(owner: $owner, name: $name) {pullRequest(number: ${{ github.event.pull_request.number }}) {id}}}' --jq '.data.repository.pullRequest.id')"
+        gh api graphql -f pr_id="$PR_ID" -f query='mutation($pr_id: String!) {enablePullRequestAutoMerge(input:{mergeMethod:SQUASH,pullRequestId:$pr_id }) {pullRequest {number}}}'
+      env:
+        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN_CWA }}

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -27,4 +27,4 @@ jobs:
         PR_ID="$(gh api graphql -F owner='{owner}' -F name='{repo}' -f query='query($owner: String!, $name: String!) {repository(owner: $owner, name: $name) {pullRequest(number: ${{ github.event.pull_request.number }}) {id}}}' --jq '.data.repository.pullRequest.id')"
         gh api graphql -f pr_id="$PR_ID" -f query='mutation($pr_id: String!) {enablePullRequestAutoMerge(input:{mergeMethod:SQUASH,pullRequestId:$pr_id }) {pullRequest {number}}}'
       env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN_CWA }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_PAT_CWA }}

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -1,0 +1,58 @@
+name: CI/CD - New updates to 'main'
+
+on:
+  push:
+    branches: [main]
+
+env:
+  DEPENDABOT_BRANCH: ci/dependabot-updates
+  GIT_USER_NAME: CIF-ontology Team
+  GIT_USER_EMAIL: "CIF-ontology@emmo.info"
+  DEFAULT_REPO_BRANCH: main
+
+jobs:
+  update-dependabot-branch:
+    name: Update permanent dependabot branch
+    if: github.repository_owner == 'emmo-repo'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ env.DEPENDABOT_BRANCH }}
+        fetch-depth: 0
+
+    - name: Set up git config
+      run: |
+        git config --global user.name "${{ env.GIT_USER_NAME }}"
+        git config --global user.email "${{ env.GIT_USER_EMAIL }}"
+
+    - name: Update '${{ env.DEPENDABOT_BRANCH }}'
+      run: |
+        git fetch origin
+
+        LATEST_PR_BODY="$(gh api /repos/${{ github.repository}}/pulls -X GET -f state=closed -f per_page=1 -f sort=updated -f direction=desc --jq '.[].body')"
+        cat .github/static/single_dependency_pr_body.txt | head -8 > .tmp_file.txt
+        if [ -z "$(printf '%s\n' "${LATEST_PR_BODY}" | head -8 | diff - .tmp_file.txt --strip-trailing-cr)" ]; then
+          # The dependency branch has just been merged into `${{ env.DEFAULT_REPO_BRANCH }}`
+          # The dependency branch should be reset to `${{ env.DEFAULT_REPO_BRANCH }}`
+          echo "The dependencies have just been updated! Reset to ${{ env.DEFAULT_REPO_BRANCH }}."
+          git reset --hard origin/${{ env.DEFAULT_REPO_BRANCH }}
+          echo "FORCE_PUSH=yes" >> $GITHUB_ENV
+        else
+          # Normal procedure: Merge `${{ env.DEFAULT_REPO_BRANCH }}` into `${{ env.DEPENDABOT_BRANCH }}`
+          echo "Merge new updates to ${{ env.DEFAULT_REPO_BRANCH }} into ${{ env.DEPENDABOT_BRANCH }}"
+          git merge -m "Keep '${{ env.DEPENDABOT_BRANCH }}' up-to-date with '${{ env.DEFAULT_REPO_BRANCH }}'" origin/${{ env.DEFAULT_REPO_BRANCH }}
+          echo "FORCE_PUSH=no" >> $GITHUB_ENV
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Push to '${{ env.DEPENDABOT_BRANCH }}'
+      uses: CasperWA/push-protected@v2
+      with:
+        token: ${{ secrets.RELEASE_TOKEN_CWA }}
+        branch: ${{ env.DEPENDABOT_BRANCH }}
+        sleep: 15
+        force: ${{ env.FORCE_PUSH }}

--- a/.github/workflows/ci_cd_updated_main.yml
+++ b/.github/workflows/ci_cd_updated_main.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Push to '${{ env.DEPENDABOT_BRANCH }}'
       uses: CasperWA/push-protected@v2
       with:
-        token: ${{ secrets.RELEASE_TOKEN_CWA }}
+        token: ${{ secrets.RELEASE_PAT_CWA }}
         branch: ${{ env.DEPENDABOT_BRANCH }}
         sleep: 15
         force: ${{ env.FORCE_PUSH }}

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -84,7 +84,7 @@ jobs:
       id: cpr
       uses: peter-evans/create-pull-request@v3
       with:
-        token: ${{ secrets.RELEASE_TOKEN_FLB }}
+        token: ${{ secrets.RELEASE_PAT_CWA }}
         commit-message: New @dependabot-fueled updates
         committer: "${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>"
         author: "${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>"

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -1,0 +1,98 @@
+name: CI - Single Dependabot PR
+
+on:
+  schedule:
+    # At 8:30 every Wednesday (6:30 UTC)
+    # Dependabot runs once a week (every Monday) (pip)
+    # and every day (GH Actions) between 7:00 and 7:30 (5:00-5:30 UTC)
+    - cron: "30 6 * * 3"
+
+jobs:
+  create-collected-pr:
+    name: Single dependabot PR
+    if: github.repository_owner == 'emmo-repo'
+    runs-on: ubuntu-latest
+    env:
+      DEPENDABOT_BRANCH: ci/dependabot-updates
+      GIT_USER_NAME: CIF-ontology Team
+      GIT_USER_EMAIL: "CIF-ontology@emmo.info"
+      DEFAULT_REPO_BRANCH: main
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ env.DEFAULT_REPO_BRANCH }}
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install `pre-commit` and dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools wheel
+
+        while IFS="" read -r line || [ -n "${line}" ]; do
+          if [[ "${line}" =~ ^pre-commit.*$ ]]; then
+            pre_commit="${line}"
+          fi
+        done < requirements_dev.txt
+
+        pip install ${pre_commit}
+
+    - name: Set up git user info
+      run: |
+        git config --global user.name "${{ env.GIT_USER_NAME }}"
+        git config --global user.email "${{ env.GIT_USER_EMAIL }}"
+
+    - name: Reset to '${{ env.DEPENDABOT_BRANCH }}'
+      run: |
+        git fetch origin ${{ env.DEPENDABOT_BRANCH }}:${{ env.DEPENDABOT_BRANCH }}
+        git reset --hard ${{ env.DEPENDABOT_BRANCH }}
+
+    - name: Auto-update `pre-commit` hooks
+      run: |
+        pre-commit autoupdate
+
+        if [ -n "$(git status --porcelain .pre-commit-config.yaml)" ]; then
+          # Set environment variable notifying next steps that the hooks changed
+          echo "Pre-commit hooks have been updated !"
+          echo "UPDATED_PRE_COMMIT_HOOKS=true" >> $GITHUB_ENV
+        else
+          echo "No pre-commit hooks have been updated."
+          echo "UPDATED_PRE_COMMIT_HOOKS=false" >> $GITHUB_ENV
+        fi
+
+    - name: Possibly run `pre-commit` with updated hooks
+      if: env.UPDATED_PRE_COMMIT_HOOKS == 'true'
+      continue-on-error: true  # Still create the PR if this step fails
+      run: SKIP=pylint pre-commit run --all-files
+
+    - name: Possibly commit changes and updates
+      if: env.UPDATED_PRE_COMMIT_HOOKS == 'true'
+      run: git commit -am "Update \`pre-commit\` hooks"
+
+    - name: Fetch PR body
+      id: pr_body
+      uses: chuhlomin/render-template@v1.2
+      with:
+        template: .github/static/single_dependency_pr_body.txt
+
+    - name: Create PR
+      id: cpr
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ secrets.RELEASE_TOKEN_FLB }}
+        commit-message: New @dependabot-fueled updates
+        committer: "${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>"
+        author: "${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>"
+        branch: ci/update-dependencies
+        delete-branch: true
+        title: "[Auto-generated] Update dependencies"
+        body: ${{ steps.pr_body.outputs.result }}
+        labels: dependencies,github_actions
+
+    - name: Information
+      run: 'echo "${{ steps.cpr.outputs.pull-request-operation }} PR #${{ steps.cpr.outputs.pull-request-number }}: ${{ steps.cpr.outputs.pull-request-url }}"'

--- a/.github/workflows/dic2owl_ci.yml
+++ b/.github/workflows/dic2owl_ci.yml
@@ -84,4 +84,4 @@ jobs:
           pip install -e dic2owl[dev]
 
       - name: Run unit tests with PyTest
-        run: pytest --cov dic2owl tests/
+        run: pytest -c dic2owl/pyproject.toml

--- a/.github/workflows/dic2owl_ci.yml
+++ b/.github/workflows/dic2owl_ci.yml
@@ -8,6 +8,60 @@ on:
       - '.github/**'
 
 jobs:
+  pre-commit-dic2owl:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools wheel
+
+        while IFS="" read -r line || [ -n "${line}" ]; do
+          if [[ "${line}" =~ ^pre-commit.*$ ]]; then
+            pre_commit="${line}"
+          fi
+        done < dic2owl/requirements_dev.txt
+
+        pip install ${pre_commit}
+
+    - name: Run pre-commit
+      run: SKIP=pylint pre-commit run --all-files
+
+  pylint-safety:
+    name: PyLint and safety
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools wheel
+
+        pip install -U -r dic2owl/requirements.txt -r dic2owl/requirements_dev.txt
+        pip install safety
+
+    - name: Run PyLint
+      run: pylint --rcfile=dic2owl/pyproject.toml dic2owl/**/*.py
+
+    - name: Run safety
+      run: pip freeze | safety check --stdin
 
   dic2owl-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/dic2owl_ci.yml
+++ b/.github/workflows/dic2owl_ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
 
-  dic2owl-lint-test:
+  dic2owl-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,23 +25,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
-          pip install -U -e dic2owl
-          pip install bandit pylint safety mypy pytest pytest-cov
-
-      - name: Run bandit
-        run: bandit -r dic2owl/dic2owl
-
-      - name: Run PyLint
-        run: pylint --rcfile=dic2owl/pyproject.toml dic2owl/dic2owl
-
-      - name: Run safety
-        run: |
-          DEPENDENCIES=$( python .github/static/get_dic2owl_deps.py dic2owl/requirements.txt dic2owl/requirements_dev.txt )
-          pip freeze | grep -E "${DEPENDENCIES}" | safety check --stdin
-
-      - name: Lint with MyPy
-        run: mypy --ignore-missing-imports --scripts-are-modules dic2owl/dic2owl
+          python -m pip install -U pip
+          pip install -U setuptools wheel
+          pip install -e dic2owl[dev]
 
       - name: Run unit tests with PyTest
         run: pytest --cov dic2owl tests/

--- a/.github/workflows/dic2owl_ci.yml
+++ b/.github/workflows/dic2owl_ci.yml
@@ -15,10 +15,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.7
 
     - name: Install dependencies
       run: |
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,9 +2,21 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.0.1
   hooks:
+  - id: check-symlinks
+  - id: check-xml
+    name: Check XML
+    files: \.(xml|rdf|ttl)$
   - id: check-yaml
+    name: Check YAML
+  - id: destroyed-symlinks
+  - id: end-of-file-fixer
+    exclude: ^.*(\.ttl|\.cif)$
+  - id: requirements-txt-fixer
+    name: Fix requirements*.txt
+    files: ^.*requirements.*\.txt$
   - id: trailing-whitespace
-    exclude: .*(\.md|\.ttl|\.cif)$
+    args: [--markdown-linebreak-ext=md]
+    exclude: ^.*(\.ttl|\.cif)$
 
 - repo: https://github.com/ambv/black
   rev: 21.11b1
@@ -13,10 +25,29 @@ repos:
     args:
       - --config=dic2owl/pyproject.toml
 
-- repo: https://github.com/pycqa/pylint
-  rev: 'v2.12.1'
+- repo: https://github.com/PyCQA/bandit
+  rev: '1.7.1'
+  hooks:
+  - id: bandit
+    args: [-r]
+    exclude: ^tests/.*$
+    files: ^dic2owl/.*$
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.910-1
+  hooks:
+  - id: mypy
+    exclude: ^tests/.*$
+    files: ^dic2owl/.*$
+    args: [--config-file, dic2owl/pyproject.toml]
+
+- repo: local
   hooks:
   - id: pylint
-    args:
-      - --rcfile=dic2owl/pyproject.toml
-      - --disable=import-error
+    name: pylint
+    entry: pylint
+    language: python
+    types: [python]
+    args: [--rcfile, dic2owl/pyproject.toml]
+    require_serial: true
+    exclude: ^tests/.*$

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cif_onto = get_ontology('https://raw.githubusercontent.com/emmo-repo/CIF-ontolog
 - [MarketPlace](https://www.the-marketplace-project.eu/);
   Grant Agreement No: 760173
   <img src="https://www.the-marketplace-project.eu/content/dam/iwm/the-marketplace-project/images/MARKETPLACE_LOGO_300dpi.png" width="120">
-- [OntoTrans](https://ontotrans.eu/); 
+- [OntoTrans](https://ontotrans.eu/);
   Grant Agreement No: 862136
   <img src="https://ontotrans.eu/wp-content/uploads/2020/05/ot_logo_rosa_gro%C3%9F.svg" height="50">
 - [BIG-MAP](https://www.big-map.eu/);

--- a/dic2owl/pyproject.toml
+++ b/dic2owl/pyproject.toml
@@ -9,8 +9,15 @@ warn_unused_configs = true
 show_error_codes = true
 allow_redefinition = true
 
-[tool.pylint.MASTER]
+[tool.pytest.ini_options]
+minversion = "6.0"
+required_plugins = "pytest-cov>=3.0"
+addopts = "-rs --cov=./dic2owl/dic2owl/ --cov-report=term"
+filterwarnings = [
+    "ignore:.*imp module.*:DeprecationWarning",
+]
 
+[tool.pylint.MASTER]
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.

--- a/dic2owl/pyproject.toml
+++ b/dic2owl/pyproject.toml
@@ -2,6 +2,13 @@
 line-length = 79
 target-version = ['py37', 'py38', 'py39']
 
+[tool.mypy]
+ignore_missing_imports = true
+scripts_are_modules = true
+warn_unused_configs = true
+show_error_codes = true
+allow_redefinition = true
+
 [tool.pylint.MASTER]
 
 # A comma-separated list of package or module names from where C extensions may

--- a/dic2owl/requirements_dev.txt
+++ b/dic2owl/requirements_dev.txt
@@ -1,6 +1,4 @@
-bandit~=1.7.0
-mypy==0.910
 pre-commit~=2.15
-pylint~=2.11
+pylint~=2.12
 pytest~=6.2
-pytest-cov~=2.12
+pytest-cov~=3.0


### PR DESCRIPTION
This adds workflows for better @dependabot automation.
The automation workflows are used in several other projects as well (Materials-Consortia/optimade-python-tools, emmo-repo/EMMO-python, CasperWA/push-protected, ...).

The CI is also updated, running `bandit`, `mypy` and `safety` always, not installing these tools explicitly in the `dic2owl`-specific CI, but rather adding it to `pre-commit`.