### PR TITLE
Ensure correct requirements_dev.txt location in CI

### DIFF
--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -1,6 +1,7 @@
 name: CI - Single Dependabot PR
 
 on:
+  pull_request:
   schedule:
     # At 8:30 every Wednesday (6:30 UTC)
     # Dependabot runs once a week (every Monday) (pip)

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -1,7 +1,6 @@
 name: CI - Single Dependabot PR
 
 on:
-  pull_request:
   schedule:
     # At 8:30 every Wednesday (6:30 UTC)
     # Dependabot runs once a week (every Monday) (pip)

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -38,7 +38,7 @@ jobs:
           if [[ "${line}" =~ ^pre-commit.*$ ]]; then
             pre_commit="${line}"
           fi
-        done < requirements_dev.txt
+        done < dic2owl/requirements_dev.txt
 
         pip install ${pre_commit}
 


### PR DESCRIPTION
Fixes #72.

Note, this temporarily runs the "create single dependencies PR" workflow upon PRs - this should be removed before merging.