### PR TITLE
Remove all ignored safety IDs

### DIFF
--- a/.github/workflows/dic2owl_ci.yml
+++ b/.github/workflows/dic2owl_ci.yml
@@ -53,12 +53,8 @@ jobs:
     - name: Run PyLint
       run: pylint --rcfile=dic2owl/pyproject.toml dic2owl/**/*.py
 
-      # Ignore ID 44715 for now.
-      # See this NumPy issue for more information: https://github.com/numpy/numpy/issues/19038
-      # Remove ignoring 48547 as soon as RDFLib/rdflib#1844 has been fixed and the fix
-      # has been released.
     - name: Run safety
-      run: pip freeze | safety check --stdin --ignore 44715 --ignore 44716 --ignore 44717 --ignore 48547
+      run: pip freeze | safety check --stdin
 
   dic2owl-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/dic2owl_ci.yml
+++ b/.github/workflows/dic2owl_ci.yml
@@ -53,8 +53,13 @@ jobs:
     - name: Run PyLint
       run: pylint --rcfile=dic2owl/pyproject.toml dic2owl/**/*.py
 
+      # Ignore ID 44715, 44716, and 44717 for now.
+      # See this NumPy issue for more information:
+      # https://github.com/numpy/numpy/issues/19038
+      # When dropping Python 3.7 support, these vulnerabilities are fixed and can be
+      # removed from the ignore list.
     - name: Run safety
-      run: pip freeze | safety check --stdin
+      run: pip freeze | safety check --stdin --ignore 44715 --ignore 44716 --ignore 44717
 
   dic2owl-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #109 

Remove ignoring safety IDs in the CI.
If the safety check succeeds, I will assume the vulnerability has been "patched" - or rather that it is no longer relevant.

EDIT: "Only" NumPy vulnerabilities are found. This is due to the inability of upgrading to a NumPy version where the listed vulnerabilities are "fixed" because of Python 3.7 support. The versions with the fixes are not Python 3.7 supported.
See [this run](https://github.com/emmo-repo/CIF-ontology/actions/runs/6666737449/job/18118840451?pr=179) to see the NumPy vulnerabilities.

The NumPy vulnerabilities will be re-ignored.

It is worth noting that the RDFLib vulnerability is no longer present. So the issue can be closed.

However, we should upgrade to Python 3.8+.